### PR TITLE
Use released version of felix maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,10 @@
           </execution>
         </executions>
       </plugin>
-      <!-- TODO: CHANGE TO RELEASE VERSION WHEN MAVEN-BUNDLE-PLUGIN:2.4.0 RELEASED -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0</version>
       </plugin>
       <plugin>
         <!-- Inherited from oss-base. Generate PackageVersion.java.-->


### PR DESCRIPTION
Also note, a change in recent build of Java 8 means you can use the existing 2.2.1-beta2  version. You get this exception.

java.lang.invoke.LambdaMetafactory.metaFactory(Lookup,String,MethodType,MethodHandle,MethodHandle,MethodType)CallSite/invokeStatic )   

This post  http://mail.openjdk.java.net/pipermail/lambda-dev/2013-July/010474.html  says a recompile is required.

Please can you publish a new version onto maven-central  (making sure it's built using recent Java 8 build).
