### PR TITLE
PR to resolve #18: Key deserializing

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
@@ -41,14 +41,19 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.OffsetTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.YearDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.DurationKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.InstantKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.LocalDateKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.LocalDateTimeKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.LocalTimeKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.MonthDayKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.OffsetDateTimeKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.OffsetTimeKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.PeriodKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.YearKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.YearMothKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.ZoneIdKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.ZoneOffsetKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.key.ZonedDateTimeKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.DurationSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
@@ -149,14 +154,19 @@ public final class JSR310Module extends SimpleModule
         addSerializer(ZoneOffset.class, ToStringSerializer.instance);
 
         // key deserializers
+        addKeyDeserializer(Duration.class, DurationKeyDeserializer.INSTANCE);
         addKeyDeserializer(Instant.class, InstantKeyDeserializer.INSTANCE);
-        addKeyDeserializer(LocalDate.class, LocalDateKeyDeserializer.INSTANCE);
         addKeyDeserializer(LocalDateTime.class, LocalDateTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(LocalDate.class, LocalDateKeyDeserializer.INSTANCE);
         addKeyDeserializer(LocalTime.class, LocalTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(MonthDay.class, MonthDayKeyDeserializer.INSTANCE);
         addKeyDeserializer(OffsetDateTime.class, OffsetDateTimeKeyDeserializer.INSTANCE);
         addKeyDeserializer(OffsetTime.class, OffsetTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(Period.class, PeriodKeyDeserializer.INSTANCE);
         addKeyDeserializer(Year.class, YearKeyDeserializer.INSTANCE);
         addKeyDeserializer(YearMonth.class, YearMothKeyDeserializer.INSTANCE);
         addKeyDeserializer(ZonedDateTime.class, ZonedDateTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(ZoneId.class, ZoneIdKeyDeserializer.INSTANCE);
+        addKeyDeserializer(ZoneOffset.class, ZoneOffsetKeyDeserializer.INSTANCE);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
@@ -64,6 +64,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.OffsetDateTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.OffsetTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.YearSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.key.ZonedDateTimeKeySerializer;
 
 /**
  * Class that registers this module with the Jackson core.<br>
@@ -152,6 +153,9 @@ public final class JSR310Module extends SimpleModule
         addSerializer(ZonedDateTime.class, ZonedDateTimeSerializer.INSTANCE);
         addSerializer(ZoneId.class, ToStringSerializer.instance);
         addSerializer(ZoneOffset.class, ToStringSerializer.instance);
+
+        // key serializers
+        addKeySerializer(ZonedDateTime.class, ZonedDateTimeKeySerializer.INSTANCE);
 
         // key deserializers
         addKeyDeserializer(Duration.class, DurationKeyDeserializer.INSTANCE);

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
@@ -41,6 +41,15 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.OffsetTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.YearDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.InstantKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.LocalDateKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.LocalDateTimeKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.LocalTimeKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.OffsetDateTimeKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.OffsetTimeKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.YearKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.YearMothKeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.key.ZonedDateTimeKeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.DurationSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
@@ -50,7 +59,6 @@ import com.fasterxml.jackson.datatype.jsr310.ser.OffsetDateTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.OffsetTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.YearSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
-
 
 /**
  * Class that registers this module with the Jackson core.<br>
@@ -138,5 +146,16 @@ public final class JSR310Module extends SimpleModule
         addSerializer(ZonedDateTime.class, ZonedDateTimeSerializer.INSTANCE);
         addSerializer(ZoneId.class, ToStringSerializer.instance);
         addSerializer(ZoneOffset.class, ToStringSerializer.instance);
+
+        // key deserializers
+        addKeyDeserializer(Instant.class, InstantKeyDeserializer.INSTANCE);
+        addKeyDeserializer(LocalDate.class, LocalDateKeyDeserializer.INSTANCE);
+        addKeyDeserializer(LocalDateTime.class, LocalDateTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(LocalTime.class, LocalTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(OffsetDateTime.class, OffsetDateTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(OffsetTime.class, OffsetTimeKeyDeserializer.INSTANCE);
+        addKeyDeserializer(Year.class, YearKeyDeserializer.INSTANCE);
+        addKeyDeserializer(YearMonth.class, YearMothKeyDeserializer.INSTANCE);
+        addKeyDeserializer(ZonedDateTime.class, ZonedDateTimeKeyDeserializer.INSTANCE);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/JSR310Module.java
@@ -106,6 +106,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
  *
  * @author Nick Williams
  * @since 2.2.0
+ * @see com.fasterxml.jackson.datatype.jsr310.ser.key.Jsr310NullKeySerializer
  */
 public final class JSR310Module extends SimpleModule
 {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/DurationKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/DurationKeyDeserializer.java
@@ -9,7 +9,7 @@ public class DurationKeyDeserializer extends Jsr310KeyDeserializer {
     public static final DurationKeyDeserializer INSTANCE = new DurationKeyDeserializer();
 
     private DurationKeyDeserializer() {
-        // string
+        // singleton
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/DurationKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/DurationKeyDeserializer.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.Duration;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class DurationKeyDeserializer extends Jsr310KeyDeserializer {
+
+    public static final DurationKeyDeserializer INSTANCE = new DurationKeyDeserializer();
+
+    private DurationKeyDeserializer() {
+        // string
+    }
+
+    @Override
+    protected Duration deserialize(String key, DeserializationContext ctxt) {
+        return Duration.parse(key);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantDeserializer.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class InstantDeserializer extends Jsr310KeyDeserializer<Instant> {
+
+    @Override
+    protected Instant deserialize(String key, DeserializationContext ctxt) {
+        return DateTimeFormatter.ISO_INSTANT.parse(key, Instant::from);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantKeyDeserializer.java
@@ -5,7 +5,13 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class InstantDeserializer extends Jsr310KeyDeserializer<Instant> {
+public class InstantKeyDeserializer extends Jsr310KeyDeserializer<Instant> {
+
+    public static final InstantKeyDeserializer INSTANCE = new InstantKeyDeserializer();
+
+    private InstantKeyDeserializer() {
+        // singleton
+    }
 
     @Override
     protected Instant deserialize(String key, DeserializationContext ctxt) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantKeyDeserializer.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class InstantKeyDeserializer extends Jsr310KeyDeserializer<Instant> {
+public class InstantKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final InstantKeyDeserializer INSTANCE = new InstantKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.io.IOException;
+import java.time.temporal.Temporal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+
+abstract class Jsr310KeyDeserializer<T extends Temporal> extends KeyDeserializer {
+
+	@Override
+	public final Object deserializeKey(String key, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+		if (key.length() == 0) {
+			// potential null key in HashMap
+			return null;
+		}
+		return deserialize(key, ctxt);
+	}
+
+	protected abstract T deserialize(String key, DeserializationContext ctxt) throws IOException, JsonProcessingException;
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
@@ -4,12 +4,13 @@ import java.time.temporal.Temporal;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.key.Jsr310NullKeySerializer;
 
 abstract class Jsr310KeyDeserializer<T extends Temporal> extends KeyDeserializer {
 
     @Override
     public final Object deserializeKey(String key, DeserializationContext ctxt) {
-        if (key.length() == 0) {
+        if (Jsr310NullKeySerializer.NULL_KEY.equals(key)) {
             // potential null key in HashMap
             return null;
         }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
@@ -1,12 +1,10 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
-import java.time.temporal.Temporal;
-
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.key.Jsr310NullKeySerializer;
 
-abstract class Jsr310KeyDeserializer<T extends Temporal> extends KeyDeserializer {
+abstract class Jsr310KeyDeserializer extends KeyDeserializer {
 
     @Override
     public final Object deserializeKey(String key, DeserializationContext ctxt) {
@@ -17,5 +15,5 @@ abstract class Jsr310KeyDeserializer<T extends Temporal> extends KeyDeserializer
         return deserialize(key, ctxt);
     }
 
-    protected abstract T deserialize(String key, DeserializationContext ctxt);
+    protected abstract Object deserialize(String key, DeserializationContext ctxt);
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/Jsr310KeyDeserializer.java
@@ -1,22 +1,20 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
-import java.io.IOException;
 import java.time.temporal.Temporal;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 
 abstract class Jsr310KeyDeserializer<T extends Temporal> extends KeyDeserializer {
 
-	@Override
-	public final Object deserializeKey(String key, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-		if (key.length() == 0) {
-			// potential null key in HashMap
-			return null;
-		}
-		return deserialize(key, ctxt);
-	}
+    @Override
+    public final Object deserializeKey(String key, DeserializationContext ctxt) {
+        if (key.length() == 0) {
+            // potential null key in HashMap
+            return null;
+        }
+        return deserialize(key, ctxt);
+    }
 
-	protected abstract T deserialize(String key, DeserializationContext ctxt) throws IOException, JsonProcessingException;
+    protected abstract T deserialize(String key, DeserializationContext ctxt);
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateDeserializer.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class LocalDateDeserializer extends Jsr310KeyDeserializer<LocalDate> {
+
+	@Override
+	protected LocalDate deserialize(String key, DeserializationContext ctxt) {
+		// TODO handle LocalDate.toEpochDay() result
+		return LocalDate.parse(key, DateTimeFormatter.ISO_LOCAL_DATE);
+	}
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateDeserializer.java
@@ -7,10 +7,9 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class LocalDateDeserializer extends Jsr310KeyDeserializer<LocalDate> {
 
-	@Override
-	protected LocalDate deserialize(String key, DeserializationContext ctxt) {
-		// TODO handle LocalDate.toEpochDay() result
-		return LocalDate.parse(key, DateTimeFormatter.ISO_LOCAL_DATE);
-	}
+    @Override
+    protected LocalDate deserialize(String key, DeserializationContext ctxt) {
+        return LocalDate.parse(key, DateTimeFormatter.ISO_LOCAL_DATE);
+    }
 
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateKeyDeserializer.java
@@ -5,7 +5,13 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class LocalDateDeserializer extends Jsr310KeyDeserializer<LocalDate> {
+public class LocalDateKeyDeserializer extends Jsr310KeyDeserializer<LocalDate> {
+
+    public static final LocalDateKeyDeserializer INSTANCE = new LocalDateKeyDeserializer();
+
+    private LocalDateKeyDeserializer() {
+        // singleton
+    }
 
     @Override
     protected LocalDate deserialize(String key, DeserializationContext ctxt) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateKeyDeserializer.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class LocalDateKeyDeserializer extends Jsr310KeyDeserializer<LocalDate> {
+public class LocalDateKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final LocalDateKeyDeserializer INSTANCE = new LocalDateKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
@@ -7,6 +7,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class LocalDateTimeKeyDeserializer extends Jsr310KeyDeserializer<LocalDateTime> {
 
+    public static final LocalDateTimeKeyDeserializer INSTANCE = new LocalDateTimeKeyDeserializer();
+
+    private LocalDateTimeKeyDeserializer() {
+        // singleton
+    }
+
     @Override
     protected LocalDateTime deserialize(String key, DeserializationContext ctxt) {
         return LocalDateTime.parse(key, DateTimeFormatter.ISO_LOCAL_DATE_TIME);

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class LocalDateTimeKeyDeserializer extends Jsr310KeyDeserializer<LocalDateTime> {
+public class LocalDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final LocalDateTimeKeyDeserializer INSTANCE = new LocalDateTimeKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class LocalDateTimeKeyDeserializer extends Jsr310KeyDeserializer<LocalDateTime> {
+
+    @Override
+    protected LocalDateTime deserialize(String key, DeserializationContext ctxt) {
+        return LocalDateTime.parse(key, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class LocalTimeKeyDeserializer extends Jsr310KeyDeserializer<LocalTime> {
+public class LocalTimeKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final LocalTimeKeyDeserializer INSTANCE = new LocalTimeKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
@@ -7,6 +7,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class LocalTimeKeyDeserializer extends Jsr310KeyDeserializer<LocalTime> {
 
+    public static final LocalTimeKeyDeserializer INSTANCE = new LocalTimeKeyDeserializer();
+
+    private LocalTimeKeyDeserializer() {
+        // singleton
+    }
+
     @Override
     protected LocalTime deserialize(String key, DeserializationContext ctxt) {
         return LocalTime.parse(key, DateTimeFormatter.ISO_LOCAL_TIME);

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class LocalTimeKeyDeserializer extends Jsr310KeyDeserializer<LocalTime> {
+
+    @Override
+    protected LocalTime deserialize(String key, DeserializationContext ctxt) {
+        return LocalTime.parse(key, DateTimeFormatter.ISO_LOCAL_TIME);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/MonthDayKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/MonthDayKeyDeserializer.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class MonthDayKeyDeserializer extends Jsr310KeyDeserializer {
+
+    public static final MonthDayKeyDeserializer INSTANCE = new MonthDayKeyDeserializer();
+
+    // formatter copied from MonthDay
+    private static final DateTimeFormatter PARSER = new DateTimeFormatterBuilder()
+            .appendLiteral("--")
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendLiteral('-')
+            .appendValue(DAY_OF_MONTH, 2)
+            .toFormatter();
+
+    private MonthDayKeyDeserializer() {
+        // singleton
+    }
+
+    @Override
+    protected MonthDay deserialize(String key, DeserializationContext ctxt) {
+        return MonthDay.parse(key, PARSER);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class OffsetDateTimeKeyDeserializer extends Jsr310KeyDeserializer<OffsetDateTime> {
+public class OffsetDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final OffsetDateTimeKeyDeserializer INSTANCE = new OffsetDateTimeKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class OffsetDateTimeKeyDeserializer extends Jsr310KeyDeserializer<OffsetDateTime> {
+
+    @Override
+    protected OffsetDateTime deserialize(String key, DeserializationContext ctxt) {
+        return OffsetDateTime.parse(key, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
@@ -7,6 +7,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class OffsetDateTimeKeyDeserializer extends Jsr310KeyDeserializer<OffsetDateTime> {
 
+    public static final OffsetDateTimeKeyDeserializer INSTANCE = new OffsetDateTimeKeyDeserializer();
+
+    private OffsetDateTimeKeyDeserializer() {
+        // singleton
+    }
+
     @Override
     protected OffsetDateTime deserialize(String key, DeserializationContext ctxt) {
         return OffsetDateTime.parse(key, DateTimeFormatter.ISO_OFFSET_DATE_TIME);

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
@@ -7,6 +7,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class OffsetTimeKeyDeserializer extends Jsr310KeyDeserializer<OffsetTime> {
 
+    public static final OffsetTimeKeyDeserializer INSTANCE = new OffsetTimeKeyDeserializer();
+
+    private OffsetTimeKeyDeserializer() {
+        // singleton
+    }
+
     @Override
     protected OffsetTime deserialize(String key, DeserializationContext ctxt) {
         return OffsetTime.parse(key, DateTimeFormatter.ISO_OFFSET_TIME);

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class OffsetTimeKeyDeserializer extends Jsr310KeyDeserializer<OffsetTime> {
+public class OffsetTimeKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final OffsetTimeKeyDeserializer INSTANCE = new OffsetTimeKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class OffsetTimeKeyDeserializer extends Jsr310KeyDeserializer<OffsetTime> {
+
+    @Override
+    protected OffsetTime deserialize(String key, DeserializationContext ctxt) {
+        return OffsetTime.parse(key, DateTimeFormatter.ISO_OFFSET_TIME);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/PeriodKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/PeriodKeyDeserializer.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.Period;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class PeriodKeyDeserializer extends Jsr310KeyDeserializer {
+
+    public static final PeriodKeyDeserializer INSTANCE = new PeriodKeyDeserializer();
+
+    private PeriodKeyDeserializer() {
+        // singletin
+    }
+
+    @Override
+    protected Period deserialize(String key, DeserializationContext ctxt) {
+        return Period.parse(key);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
@@ -1,0 +1,27 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.Year;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class YearKeyDeserializer extends Jsr310KeyDeserializer<Year> {
+
+    /*
+     * formatter copied from Year. There is no way of getting a reference to the
+     * formatter it uses.
+     */
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .toFormatter();
+
+    @Override
+    protected Year deserialize(String key, DeserializationContext ctxt) {
+        return Year.parse(key, FORMATTER);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
@@ -11,13 +11,18 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class YearKeyDeserializer extends Jsr310KeyDeserializer<Year> {
 
+    public static final YearKeyDeserializer INSTANCE = new YearKeyDeserializer();
+
     /*
-     * formatter copied from Year. There is no way of getting a reference to the
-     * formatter it uses.
+     * formatter copied from Year. There is no way of getting a reference to the formatter it uses.
      */
     private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
             .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
             .toFormatter();
+
+    private YearKeyDeserializer() {
+        // singleton
+    }
 
     @Override
     protected Year deserialize(String key, DeserializationContext ctxt) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
@@ -9,7 +9,7 @@ import java.time.format.SignStyle;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class YearKeyDeserializer extends Jsr310KeyDeserializer<Year> {
+public class YearKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final YearKeyDeserializer INSTANCE = new YearKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
@@ -12,12 +12,18 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class YearMothKeyDeserializer extends Jsr310KeyDeserializer<YearMonth> {
 
+    public static final YearMothKeyDeserializer INSTANCE = new YearMothKeyDeserializer();
+
     // parser copied from YearMonth
     private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
             .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
             .appendLiteral('-')
             .appendValue(MONTH_OF_YEAR, 2)
             .toFormatter();
+
+    private YearMothKeyDeserializer() {
+        // singleton
+    }
 
     @Override
     protected YearMonth deserialize(String key, DeserializationContext ctxt) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
@@ -10,7 +10,7 @@ import java.time.format.SignStyle;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class YearMothKeyDeserializer extends Jsr310KeyDeserializer<YearMonth> {
+public class YearMothKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final YearMothKeyDeserializer INSTANCE = new YearMothKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
@@ -1,0 +1,27 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class YearMothKeyDeserializer extends Jsr310KeyDeserializer<YearMonth> {
+
+    // parser copied from YearMonth
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral('-')
+            .appendValue(MONTH_OF_YEAR, 2)
+            .toFormatter();
+
+    @Override
+    protected YearMonth deserialize(String key, DeserializationContext ctxt) {
+        return YearMonth.parse(key, FORMATTER);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneIdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneIdKeyDeserializer.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.ZoneId;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class ZoneIdKeyDeserializer extends Jsr310KeyDeserializer {
+
+    public static final ZoneIdKeyDeserializer INSTANCE = new ZoneIdKeyDeserializer();
+
+    private ZoneIdKeyDeserializer() {
+        // singleton
+    }
+
+    @Override
+    protected Object deserialize(String key, DeserializationContext ctxt) {
+        return ZoneId.of(key);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneOffsetKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneOffsetKeyDeserializer.java
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.ZoneOffset;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class ZoneOffsetKeyDeserializer extends Jsr310KeyDeserializer {
+
+    public static final ZoneOffsetKeyDeserializer INSTANCE = new ZoneOffsetKeyDeserializer();
+
+    private ZoneOffsetKeyDeserializer() {
+        // singleton
+    }
+
+    @Override
+    protected ZoneOffset deserialize(String key, DeserializationContext ctxt) {
+        return ZoneOffset.of(key);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+public class ZonedDateTimeKeyDeserializer extends Jsr310KeyDeserializer<ZonedDateTime> {
+
+    @Override
+    protected ZonedDateTime deserialize(String key, DeserializationContext ctxt) {
+        // not serializing timezone data yet
+        return ZonedDateTime.parse(key, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
@@ -7,6 +7,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 public class ZonedDateTimeKeyDeserializer extends Jsr310KeyDeserializer<ZonedDateTime> {
 
+    public static final ZonedDateTimeKeyDeserializer INSTANCE = new ZonedDateTimeKeyDeserializer();
+
+    private ZonedDateTimeKeyDeserializer() {
+        // singleton
+    }
+
     @Override
     protected ZonedDateTime deserialize(String key, DeserializationContext ctxt) {
         // not serializing timezone data yet

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
-public class ZonedDateTimeKeyDeserializer extends Jsr310KeyDeserializer<ZonedDateTime> {
+public class ZonedDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final ZonedDateTimeKeyDeserializer INSTANCE = new ZonedDateTimeKeyDeserializer();
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/key/Jsr310NullKeySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/key/Jsr310NullKeySerializer.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.datatype.jsr310.ser.key;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * This class is to be used in case {@code null} keys are needed to be serialized in a {@link Map} with Java 8 temporal keys. By default the
+ * {@code null} key is not supported by jackson, the serializer needs to be registered manually.
+ *
+ * @author Zoltan Kiss
+ * @since 2.6
+ */
+public class Jsr310NullKeySerializer extends JsonSerializer<Object> {
+
+    public static final String NULL_KEY = "";
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers) throws IOException,
+            JsonProcessingException {
+        if (value != null) {
+            throw new JsonMappingException("Jsr310NullKeySerializer is only for serializing null values.");
+        }
+
+        gen.writeFieldName(NULL_KEY);
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/key/ZonedDateTimeKeySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/key/ZonedDateTimeKeySerializer.java
@@ -1,0 +1,31 @@
+package com.fasterxml.jackson.datatype.jsr310.ser.key;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class ZonedDateTimeKeySerializer extends JsonSerializer<ZonedDateTime> {
+
+    public static final ZonedDateTimeKeySerializer INSTANCE = new ZonedDateTimeKeySerializer();
+
+    private ZonedDateTimeKeySerializer() {
+        // singleton
+    }
+
+    @Override
+    public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException,
+            JsonProcessingException {
+        /*
+         * Serialization of timezone data is unwanted (not ISO). Offset is kept, timezone info is thrown away here.
+         *
+         * Keeping timezone info is a new feature which needs to be implemented.
+         */
+        gen.writeFieldName(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(value));
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationKeySerialization.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -13,6 +12,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestDurationKeySerialization {
+
+    private static final TypeReference<Map<Duration, String>> TYPE_REF = new TypeReference<Map<Duration, String>>() {
+    };
+    private static final Duration DURATION = Duration.ofMinutes(13).plusSeconds(37).plusNanos(120 * 1000 * 1000);
+    private static final String DURATION_STRING = "PT13M37.12S";
 
     private ObjectMapper om;
     private Map<Duration, String> map;
@@ -30,23 +34,20 @@ public class TestDurationKeySerialization {
 
     @Test
     public void testSerialization() throws Exception {
-        map.put(Duration.ofMinutes(13).plusSeconds(37).plusNanos(123), "test");
+        map.put(DURATION, "test");
 
         String value = om.writeValueAsString(map);
 
-        assertNotNull("Value should not be null", value);
-        assertEquals("Value is not correct", map("PT13M37.000000123S", "test"), value);
+        assertEquals("Value is not correct", map(DURATION_STRING, "test"), value);
     }
 
     @Test
     public void testDeserialization() throws Exception {
         Map<Duration, String> value = om.readValue(
-                map("PT13M37.000000123S", "test"),
-                new TypeReference<Map<Duration, String>>() {
-                });
+                map(DURATION_STRING, "test"),
+                TYPE_REF);
 
-        assertNotNull("Value should not be null", value);
-        map.put(Duration.ofMinutes(13).plusSeconds(37).plusNanos(123), "test");
+        map.put(DURATION, "test");
         assertEquals("Value is not correct", map, value);
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationKeySerialization.java
@@ -1,0 +1,57 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestDurationKeySerialization {
+
+    private ObjectMapper om;
+    private Map<Duration, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() throws Exception {
+        map.put(Duration.ofMinutes(13).plusSeconds(37).plusNanos(123), "test");
+
+        String value = om.writeValueAsString(map);
+
+        assertNotNull("Value should not be null", value);
+        assertEquals("Value is not correct", map("PT13M37.000000123S", "test"), value);
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        Map<Duration, String> value = om.readValue(
+                map("PT13M37.000000123S", "test"),
+                new TypeReference<Map<Duration, String>>() {
+                });
+
+        assertNotNull("Value should not be null", value);
+        map.put(Duration.ofMinutes(13).plusSeconds(37).plusNanos(123), "test");
+        assertEquals("Value is not correct", map, value);
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
@@ -14,8 +14,10 @@ import org.junit.Test;
 
 public class TestInstantKeySerialization {
 
-    private static final String INSTANT_STRING = "2011-07-19T21:35:11.000000123Z";
-    private static final Instant INSTANT = Instant.ofEpochSecond(1311111311l, 123);
+    private static final TypeReference<Map<Instant, String>> TYPE_REF = new TypeReference<Map<Instant, String>>() {
+    };
+    private static final String INSTANT_STRING = "2015-03-14T09:26:53.590Z";
+    private static final Instant INSTANT = Instant.ofEpochSecond(1426325213l, 590000000l);
 
     private ObjectMapper om;
     private Map<Instant, String> map;
@@ -51,8 +53,7 @@ public class TestInstantKeySerialization {
 
     @Test
     public void testDeserialization0() throws Exception {
-        Map<Instant, String> value = om.readValue(map("1970-01-01T00:00:00Z", "test"), new TypeReference<Map<Instant, String>>() {
-        });
+        Map<Instant, String> value = om.readValue(map("1970-01-01T00:00:00Z", "test"), TYPE_REF);
 
         map.put(Instant.ofEpochMilli(0), "test");
         assertEquals("Value is incorrect", map, value);
@@ -60,8 +61,7 @@ public class TestInstantKeySerialization {
 
     @Test
     public void testDeserialization1() throws Exception {
-        Map<Instant, String> value = om.readValue(map(INSTANT_STRING, "test"), new TypeReference<Map<Instant, String>>() {
-        });
+        Map<Instant, String> value = om.readValue(map(INSTANT_STRING, "test"), TYPE_REF);
 
         map.put(INSTANT, "test");
         assertEquals("Value is incorrect", map, value);

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestInstantKeySerialization {
+
+    private ObjectMapper om;
+    private Map<Instant, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
@@ -16,8 +16,10 @@ public class TestInstantKeySerialization {
 
     private static final TypeReference<Map<Instant, String>> TYPE_REF = new TypeReference<Map<Instant, String>>() {
     };
-    private static final String INSTANT_STRING = "2015-03-14T09:26:53.590Z";
+    private static final Instant INSTANT_0 = Instant.ofEpochMilli(0);
+    private static final String INSTANT_0_STRING = "1970-01-01T00:00:00Z";
     private static final Instant INSTANT = Instant.ofEpochSecond(1426325213l, 590000000l);
+    private static final String INSTANT_STRING = "2015-03-14T09:26:53.590Z";
 
     private ObjectMapper om;
     private Map<Instant, String> map;
@@ -35,11 +37,11 @@ public class TestInstantKeySerialization {
 
     @Test
     public void testSerialization0() throws Exception {
-        map.put(Instant.ofEpochMilli(0), "test");
+        map.put(INSTANT_0, "test");
 
         String value = om.writeValueAsString(map);
 
-        Assert.assertEquals("Value is incorrect", map("1970-01-01T00:00:00Z", "test"), value);
+        Assert.assertEquals("Value is incorrect", map(INSTANT_0_STRING, "test"), value);
     }
 
     @Test
@@ -53,9 +55,9 @@ public class TestInstantKeySerialization {
 
     @Test
     public void testDeserialization0() throws Exception {
-        Map<Instant, String> value = om.readValue(map("1970-01-01T00:00:00Z", "test"), TYPE_REF);
+        Map<Instant, String> value = om.readValue(map(INSTANT_0_STRING, "test"), TYPE_REF);
 
-        map.put(Instant.ofEpochMilli(0), "test");
+        map.put(INSTANT_0, "test");
         assertEquals("Value is incorrect", map, value);
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantKeySerialization.java
@@ -1,15 +1,21 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import static org.junit.Assert.assertEquals;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestInstantKeySerialization {
+
+    private static final String INSTANT_STRING = "2011-07-19T21:35:11.000000123Z";
+    private static final Instant INSTANT = Instant.ofEpochSecond(1311111311l, 123);
 
     private ObjectMapper om;
     private Map<Instant, String> map;
@@ -26,15 +32,39 @@ public class TestInstantKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(Instant.ofEpochMilli(0), "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map("1970-01-01T00:00:00Z", "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(INSTANT, "test");
+
+        String value = om.writeValueAsString(map);
+
+        assertEquals("Value is incorrect", map(INSTANT_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<Instant, String> value = om.readValue(map("1970-01-01T00:00:00Z", "test"), new TypeReference<Map<Instant, String>>() {
+        });
+
+        map.put(Instant.ofEpochMilli(0), "test");
+        assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<Instant, String> value = om.readValue(map(INSTANT_STRING, "test"), new TypeReference<Map<Instant, String>>() {
+        });
+
+        map.put(INSTANT, "test");
+        assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateKeySerialization.java
@@ -1,0 +1,43 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestLocalDateKeySerialization {
+
+    private ObjectMapper om;
+    private Map<LocalDate, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateKeySerialization.java
@@ -13,6 +13,11 @@ import org.junit.Test;
 
 public class TestLocalDateKeySerialization {
 
+    private static final TypeReference<Map<LocalDate, String>> TYPE_REF = new TypeReference<Map<LocalDate, String>>() {
+    };
+    private static final LocalDate DATE = LocalDate.of(2015, 3, 14);
+    private static final String DATE_STRING = "2015-03-14";
+
     private ObjectMapper om;
     private Map<LocalDate, String> map;
 
@@ -29,19 +34,20 @@ public class TestLocalDateKeySerialization {
 
     @Test
     public void testSerialization() throws Exception {
-        map.put(LocalDate.of(2015, 3, 14), "test");
+        map.put(DATE, "test");
 
         String value = om.writeValueAsString(map);
 
-        assertEquals("Incorrect value", map("2015-03-14", "test"), value);
+        assertEquals("Incorrect value", map(DATE_STRING, "test"), value);
     }
 
     @Test
     public void testDeserialization() throws Exception {
-        Map<LocalDate, String> value = om.readValue(map("2015-03-14", "test"), new TypeReference<Map<LocalDate, String>>() {
-        });
+        Map<LocalDate, String> value = om.readValue(
+                map(DATE_STRING, "test"),
+                TYPE_REF);
 
-        map.put(LocalDate.of(2015, 3, 14), "test");
+        map.put(DATE, "test");
         assertEquals("Incorrect value", map, value);
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateKeySerialization.java
@@ -1,11 +1,13 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import static org.junit.Assert.assertEquals;
+
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,15 +28,21 @@ public class TestLocalDateKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization() throws Exception {
+        map.put(LocalDate.of(2015, 3, 14), "test");
+
+        String value = om.writeValueAsString(map);
+
+        assertEquals("Incorrect value", map("2015-03-14", "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testDeserialization() throws Exception {
+        Map<LocalDate, String> value = om.readValue(map("2015-03-14", "test"), new TypeReference<Map<LocalDate, String>>() {
+        });
+
+        map.put(LocalDate.of(2015, 3, 14), "test");
+        assertEquals("Incorrect value", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestLocalDateTimeKeySerialization {
+
+    private ObjectMapper om;
+    private Map<LocalDateTime, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeKeySerialization.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.jsr310;
 import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,8 +16,13 @@ public class TestLocalDateTimeKeySerialization {
 
     private static final TypeReference<Map<LocalDateTime, String>> TYPE_REF = new TypeReference<Map<LocalDateTime, String>>() {
     };
-    private static final LocalDateTime DATE_TIME = LocalDateTime.of(2015, 3, 14, 9, 26, 23);
-    private static final String DATE_TIME_STRING = "2015-03-14T09:26:23";
+    private static final LocalDateTime DATE_TIME_0 = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
+    /*
+     * Current serializer is LocalDateTime.toString(), which omits seconds if it can
+     */
+    private static final String DATE_TIME_0_STRING = "1970-01-01T00:00";
+    private static final LocalDateTime DATE_TIME = LocalDateTime.of(2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000);
+    private static final String DATE_TIME_STRING = "2015-03-14T09:26:53.590";
 
     private ObjectMapper om;
     private Map<LocalDateTime, String> map;
@@ -33,7 +39,16 @@ public class TestLocalDateTimeKeySerialization {
      */
 
     @Test
-    public void testSerialization() throws Exception {
+    public void testSerialization0() throws Exception {
+        map.put(DATE_TIME_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        assertEquals("Value is incorrect", map(DATE_TIME_0_STRING, "test"), value);
+    }
+
+    @Test
+    public void testSerialization1() throws Exception {
         map.put(DATE_TIME, "test");
 
         String value = om.writeValueAsString(map);
@@ -42,7 +57,17 @@ public class TestLocalDateTimeKeySerialization {
     }
 
     @Test
-    public void testDeserialization() throws Exception {
+    public void testDeserialization0() throws Exception {
+        Map<LocalDateTime, String> value = om.readValue(
+                map(DATE_TIME_0_STRING, "test"),
+                TYPE_REF);
+
+        map.put(DATE_TIME_0, "test");
+        assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
         Map<LocalDateTime, String> value = om.readValue(
                 map(DATE_TIME_STRING, "test"),
                 TYPE_REF);

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeKeySerialization.java
@@ -1,15 +1,22 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import static org.junit.Assert.assertEquals;
+
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestLocalDateTimeKeySerialization {
+
+    private static final TypeReference<Map<LocalDateTime, String>> TYPE_REF = new TypeReference<Map<LocalDateTime, String>>() {
+    };
+    private static final LocalDateTime DATE_TIME = LocalDateTime.of(2015, 3, 14, 9, 26, 23);
+    private static final String DATE_TIME_STRING = "2015-03-14T09:26:23";
 
     private ObjectMapper om;
     private Map<LocalDateTime, String> map;
@@ -26,15 +33,22 @@ public class TestLocalDateTimeKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization() throws Exception {
+        map.put(DATE_TIME, "test");
+
+        String value = om.writeValueAsString(map);
+
+        assertEquals("Value is incorrect", map(DATE_TIME_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testDeserialization() throws Exception {
+        Map<LocalDateTime, String> value = om.readValue(
+                map(DATE_TIME_STRING, "test"),
+                TYPE_REF);
+
+        map.put(DATE_TIME, "test");
+        assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeKeySerialization.java
@@ -4,12 +4,23 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestLocalTimeKeySerialization {
+
+    private static final TypeReference<Map<LocalTime, String>> TYPE_REF = new TypeReference<Map<LocalTime, String>>() {
+    };
+    private static final LocalTime TIME_0 = LocalTime.ofSecondOfDay(0);
+    /*
+     * Seconds are omitted if possible
+     */
+    private static final String TIME_0_STRING = "00:00";
+    private static final LocalTime TIME = LocalTime.of(3, 14, 15, 920 * 1000 * 1000);
+    private static final String TIME_STRING = "03:14:15.920";
 
     private ObjectMapper om;
     private Map<LocalTime, String> map;
@@ -26,15 +37,37 @@ public class TestLocalTimeKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(TIME_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(TIME_0_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(TIME, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(TIME_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<LocalTime, String> value = om.readValue(map(TIME_0_STRING, "test"), TYPE_REF);
+
+        map.put(TIME_0, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<LocalTime, String> value = om.readValue(map(TIME_STRING, "test"), TYPE_REF);
+
+        map.put(TIME, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestLocalTimeKeySerialization {
+
+    private ObjectMapper om;
+    private Map<LocalTime, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.MonthDay;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestMonthDayKeySerialization {
+
+    private ObjectMapper om;
+    private Map<MonthDay, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayKeySerialization.java
@@ -4,12 +4,18 @@ import java.time.MonthDay;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestMonthDayKeySerialization {
+
+    private static final TypeReference<Map<MonthDay, String>> TYPE_REF = new TypeReference<Map<MonthDay, String>>() {
+    };
+    private static final MonthDay MONTH_DAY = MonthDay.of(3, 14);
+    private static final String MONTH_DAY_STRING = "--03-14";
 
     private ObjectMapper om;
     private Map<MonthDay, String> map;
@@ -26,15 +32,20 @@ public class TestMonthDayKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization() throws Exception {
+        map.put(MONTH_DAY, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(MONTH_DAY_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testDeserialization() throws Exception {
+        Map<MonthDay, String> value = om.readValue(map(MONTH_DAY_STRING, "test"), TYPE_REF);
+
+        map.put(MONTH_DAY, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestNullKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestNullKeySerialization.java
@@ -1,0 +1,50 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.ser.key.Jsr310NullKeySerializer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestNullKeySerialization {
+
+    private static final TypeReference<Map<LocalDate, String>> TYPE_REF = new TypeReference<Map<LocalDate, String>>() {
+    };
+
+    private ObjectMapper om;
+    private Map<LocalDate, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        om.getSerializerProvider().setNullKeySerializer(new Jsr310NullKeySerializer());
+
+        map.put(null, "test");
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals(map(Jsr310NullKeySerializer.NULL_KEY, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        Map<LocalDate, String> value = om.readValue(map(Jsr310NullKeySerializer.NULL_KEY, "test"), TYPE_REF);
+
+        map.put(null, "test");
+        Assert.assertEquals(map, value);
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeKeySerialization.java
@@ -1,15 +1,25 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestOffsetDateTimeKeySerialization {
+
+    private static final TypeReference<Map<OffsetDateTime, String>> TYPE_REF = new TypeReference<Map<OffsetDateTime, String>>() {
+    };
+    private static final OffsetDateTime DATE_TIME_0 = OffsetDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC);
+    private static final String DATE_TIME_0_STRING = "1970-01-01T00:00Z";
+    private static final OffsetDateTime DATE_TIME = OffsetDateTime.of(2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneOffset.UTC);
+    private static final String DATE_TIME_STRING = "2015-03-14T09:26:53.590Z";
 
     private ObjectMapper om;
     private Map<OffsetDateTime, String> map;
@@ -26,15 +36,37 @@ public class TestOffsetDateTimeKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(DATE_TIME_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(DATE_TIME_0_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(DATE_TIME, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(DATE_TIME_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<OffsetDateTime, String> value = om.readValue(map(DATE_TIME_0_STRING, "test"), TYPE_REF);
+
+        map.put(DATE_TIME_0, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<OffsetDateTime, String> value = om.readValue(map(DATE_TIME_STRING, "test"), TYPE_REF);
+
+        map.put(DATE_TIME, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestOffsetDateTimeKeySerialization {
+
+    private ObjectMapper om;
+    private Map<OffsetDateTime, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeKeySerialization.java
@@ -18,8 +18,10 @@ public class TestOffsetDateTimeKeySerialization {
     };
     private static final OffsetDateTime DATE_TIME_0 = OffsetDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC);
     private static final String DATE_TIME_0_STRING = "1970-01-01T00:00Z";
-    private static final OffsetDateTime DATE_TIME = OffsetDateTime.of(2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneOffset.UTC);
-    private static final String DATE_TIME_STRING = "2015-03-14T09:26:53.590Z";
+    private static final OffsetDateTime DATE_TIME_1 = OffsetDateTime.of(2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneOffset.UTC);
+    private static final String DATE_TIME_1_STRING = "2015-03-14T09:26:53.590Z";
+    private static final OffsetDateTime DATE_TIME_2 = OffsetDateTime.of(2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneOffset.ofHours(6));
+    private static final String DATE_TIME_2_STRING = "2015-03-14T09:26:53.590+06:00";
 
     private ObjectMapper om;
     private Map<OffsetDateTime, String> map;
@@ -46,11 +48,20 @@ public class TestOffsetDateTimeKeySerialization {
 
     @Test
     public void testSerialization1() throws Exception {
-        map.put(DATE_TIME, "test");
+        map.put(DATE_TIME_1, "test");
 
         String value = om.writeValueAsString(map);
 
-        Assert.assertEquals("Value is incorrect", map(DATE_TIME_STRING, "test"), value);
+        Assert.assertEquals("Value is incorrect", map(DATE_TIME_1_STRING, "test"), value);
+    }
+
+    @Test
+    public void testSerialization2() throws Exception {
+        map.put(DATE_TIME_2, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(DATE_TIME_2_STRING, "test"), value);
     }
 
     @Test
@@ -63,9 +74,17 @@ public class TestOffsetDateTimeKeySerialization {
 
     @Test
     public void testDeserialization1() throws Exception {
-        Map<OffsetDateTime, String> value = om.readValue(map(DATE_TIME_STRING, "test"), TYPE_REF);
+        Map<OffsetDateTime, String> value = om.readValue(map(DATE_TIME_1_STRING, "test"), TYPE_REF);
 
-        map.put(DATE_TIME, "test");
+        map.put(DATE_TIME_1, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization2() throws Exception {
+        Map<OffsetDateTime, String> value = om.readValue(map(DATE_TIME_2_STRING, "test"), TYPE_REF);
+
+        map.put(DATE_TIME_2, "test");
         Assert.assertEquals("Value is incorrect", map, value);
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeKeySerialization.java
@@ -17,8 +17,10 @@ public class TestOffsetTimeKeySerialization {
     };
     private static final OffsetTime TIME_0 = OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC);
     private static final String TIME_0_STRING = "00:00Z";
-    private static final OffsetTime TIME = OffsetTime.of(3, 14, 15, 920 * 1000 * 1000, ZoneOffset.UTC);
-    private static final String TIME_STRING = "03:14:15.920Z";
+    private static final OffsetTime TIME_1 = OffsetTime.of(3, 14, 15, 920 * 1000 * 1000, ZoneOffset.UTC);
+    private static final String TIME_1_STRING = "03:14:15.920Z";
+    private static final OffsetTime TIME_2 = OffsetTime.of(3, 14, 15, 920 * 1000 * 1000, ZoneOffset.ofHours(6));
+    private static final String TIME_2_STRING = "03:14:15.920+06:00";
 
     private ObjectMapper om;
     private Map<OffsetTime, String> map;
@@ -45,11 +47,20 @@ public class TestOffsetTimeKeySerialization {
 
     @Test
     public void testSerialization1() throws Exception {
-        map.put(TIME, "test");
+        map.put(TIME_1, "test");
 
         String value = om.writeValueAsString(map);
 
-        Assert.assertEquals("Value is incorrect", map(TIME_STRING, "test"), value);
+        Assert.assertEquals("Value is incorrect", map(TIME_1_STRING, "test"), value);
+    }
+
+    @Test
+    public void testSerialization2() throws Exception {
+        map.put(TIME_2, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(TIME_2_STRING, "test"), value);
     }
 
     @Test
@@ -62,9 +73,17 @@ public class TestOffsetTimeKeySerialization {
 
     @Test
     public void testDeserialization1() throws Exception {
-        Map<OffsetTime, String> value = om.readValue(map(TIME_STRING, "test"), TYPE_REF);
+        Map<OffsetTime, String> value = om.readValue(map(TIME_1_STRING, "test"), TYPE_REF);
 
-        map.put(TIME, "test");
+        map.put(TIME_1, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization2() throws Exception {
+        Map<OffsetTime, String> value = om.readValue(map(TIME_2_STRING, "test"), TYPE_REF);
+
+        map.put(TIME_2, "test");
         Assert.assertEquals("Value is incorrect", map, value);
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeKeySerialization.java
@@ -1,15 +1,24 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
 import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestOffsetTimeKeySerialization {
+
+    private static final TypeReference<Map<OffsetTime, String>> TYPE_REF = new TypeReference<Map<OffsetTime, String>>() {
+    };
+    private static final OffsetTime TIME_0 = OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC);
+    private static final String TIME_0_STRING = "00:00Z";
+    private static final OffsetTime TIME = OffsetTime.of(3, 14, 15, 920 * 1000 * 1000, ZoneOffset.UTC);
+    private static final String TIME_STRING = "03:14:15.920Z";
 
     private ObjectMapper om;
     private Map<OffsetTime, String> map;
@@ -26,15 +35,37 @@ public class TestOffsetTimeKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(TIME_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals(map(TIME_0_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(TIME, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(TIME_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<OffsetTime, String> value = om.readValue(map(TIME_0_STRING, "test"), TYPE_REF);
+
+        map.put(TIME_0, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<OffsetTime, String> value = om.readValue(map(TIME_STRING, "test"), TYPE_REF);
+
+        map.put(TIME, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.OffsetTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestOffsetTimeKeySerialization {
+
+    private ObjectMapper om;
+    private Map<OffsetTime, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestPeriodKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestPeriodKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.Period;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPeriodKeySerialization {
+
+    private ObjectMapper om;
+    private Map<Period, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestPeriodKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestPeriodKeySerialization.java
@@ -4,12 +4,20 @@ import java.time.Period;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestPeriodKeySerialization {
+
+    private static final TypeReference<Map<Period, String>> TYPE_REF = new TypeReference<Map<Period, String>>() {
+    };
+    private static final Period PERIOD_0 = Period.of(0, 0, 0);
+    private static final String PERIOD_0_STRING = "P0D";
+    private static final Period PERIOD = Period.of(3, 1, 4);
+    private static final String PERIOD_STRING = "P3Y1M4D";
 
     private ObjectMapper om;
     private Map<Period, String> map;
@@ -26,15 +34,37 @@ public class TestPeriodKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(PERIOD_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(PERIOD_0_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(PERIOD, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(PERIOD_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<Period, String> value = om.readValue(map(PERIOD_0_STRING, "test"), TYPE_REF);
+
+        map.put(PERIOD_0, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<Period, String> value = om.readValue(map(PERIOD_STRING, "test"), TYPE_REF);
+
+        map.put(PERIOD, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.Year;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestYearKeySerialization {
+
+    private ObjectMapper om;
+    private Map<Year, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearKeySerialization.java
@@ -4,6 +4,7 @@ import java.time.Year;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,6 +12,8 @@ import org.junit.Test;
 
 public class TestYearKeySerialization {
 
+    private static final TypeReference<Map<Year, String>> TYPE_REF = new TypeReference<Map<Year, String>>() {
+    };
     private ObjectMapper om;
     private Map<Year, String> map;
 
@@ -26,15 +29,20 @@ public class TestYearKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization() throws Exception {
+        map.put(Year.of(3141), "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map("3141", "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testDeserialization() throws Exception {
+        Map<Year, String> value = om.readValue(map("3141", "test"), TYPE_REF);
+
+        map.put(Year.of(3141), "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.YearMonth;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestYearMonthKeySerialization {
+
+    private ObjectMapper om;
+    private Map<YearMonth, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthKeySerialization.java
@@ -4,12 +4,16 @@ import java.time.YearMonth;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestYearMonthKeySerialization {
+
+    private static final TypeReference<Map<YearMonth, String>> TYPE_REF = new TypeReference<Map<YearMonth, String>>() {
+    };
 
     private ObjectMapper om;
     private Map<YearMonth, String> map;
@@ -26,15 +30,20 @@ public class TestYearMonthKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization() throws Exception {
+        map.put(YearMonth.of(3141, 5), "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map("3141-05", "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testDeserialization() throws Exception {
+        Map<YearMonth, String> value = om.readValue(map("3141-05", "test"), TYPE_REF);
+
+        map.put(YearMonth.of(3141, 5), "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneIdKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneIdKeySerialization.java
@@ -4,12 +4,22 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestZoneIdKeySerialization {
+
+    private static final TypeReference<Map<ZoneId, String>> TYPE_REF = new TypeReference<Map<ZoneId, String>>() {
+    };
+    private static final ZoneId ZONE_0 = ZoneId.of("UTC");
+    private static final String ZONE_0_STRING = "UTC";
+    private static final ZoneId ZONE_1 = ZoneId.of("+06:00");
+    private static final String ZONE_1_STRING = "+06:00";
+    private static final ZoneId ZONE_2 = ZoneId.of("Europe/London");
+    private static final String ZONE_2_STRING = "Europe/London";
 
     private ObjectMapper om;
     private Map<ZoneId, String> map;
@@ -26,15 +36,54 @@ public class TestZoneIdKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(ZONE_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals(map(ZONE_0_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(ZONE_1, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(ZONE_1_STRING, "test"), value);
+    }
+
+    @Test
+    public void testSerialization2() throws Exception {
+        map.put(ZONE_2, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(ZONE_2_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<ZoneId, String> value = om.readValue(map(ZONE_0_STRING, "test"), TYPE_REF);
+
+        map.put(ZONE_0, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<ZoneId, String> value = om.readValue(map(ZONE_1_STRING, "test"), TYPE_REF);
+
+        map.put(ZONE_1, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization2() throws Exception {
+        Map<ZoneId, String> value = om.readValue(map(ZONE_2_STRING, "test"), TYPE_REF);
+
+        map.put(ZONE_2, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneIdKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneIdKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestZoneIdKeySerialization {
+
+    private ObjectMapper om;
+    private Map<ZoneId, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneIdKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneIdKeySerialization.java
@@ -41,7 +41,7 @@ public class TestZoneIdKeySerialization {
 
         String value = om.writeValueAsString(map);
 
-        Assert.assertEquals(map(ZONE_0_STRING, "test"), value);
+        Assert.assertEquals("Value is incorrect", map(ZONE_0_STRING, "test"), value);
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneOffsetKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneOffsetKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestZoneOffsetKeySerialization {
+
+    private ObjectMapper om;
+    private Map<ZoneOffset, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneOffsetKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneOffsetKeySerialization.java
@@ -39,7 +39,7 @@ public class TestZoneOffsetKeySerialization {
 
         String value = om.writeValueAsString(map);
 
-        Assert.assertEquals(map(OFFSET_0_STRING, "test"), value);
+        Assert.assertEquals("Value is incorrect", map(OFFSET_0_STRING, "test"), value);
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneOffsetKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZoneOffsetKeySerialization.java
@@ -4,12 +4,20 @@ import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestZoneOffsetKeySerialization {
+
+    private static final TypeReference<Map<ZoneOffset, String>> TYPE_REF = new TypeReference<Map<ZoneOffset, String>>() {
+    };
+    private static final ZoneOffset OFFSET_0 = ZoneOffset.UTC;
+    private static final String OFFSET_0_STRING = "Z";
+    private static final ZoneOffset OFFSET_1 = ZoneOffset.ofHours(6);
+    private static final String OFFSET_1_STRING = "+06:00";
 
     private ObjectMapper om;
     private Map<ZoneOffset, String> map;
@@ -26,15 +34,37 @@ public class TestZoneOffsetKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(OFFSET_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals(map(OFFSET_0_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(OFFSET_1, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(OFFSET_1_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<ZoneOffset, String> value = om.readValue(map(OFFSET_0_STRING, "test"), TYPE_REF);
+
+        map.put(OFFSET_0, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<ZoneOffset, String> value = om.readValue(map(OFFSET_1_STRING, "test"), TYPE_REF);
+
+        map.put(OFFSET_1, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeKeySerialization.java
@@ -18,11 +18,11 @@ public class TestZonedDateTimeKeySerialization {
     private static final TypeReference<Map<ZonedDateTime, String>> TYPE_REF = new TypeReference<Map<ZonedDateTime, String>>() {
     };
     private static final ZonedDateTime DATE_TIME_0 = ZonedDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC);
-    private static final String DATE_TIME_0_STRING = "1970-01-01T00:00Z";
+    private static final String DATE_TIME_0_STRING = "1970-01-01T00:00:00Z";
 
     private static final ZonedDateTime DATE_TIME_1 = ZonedDateTime.of(
             2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneOffset.UTC);
-    private static final String DATE_TIME_1_STRING = "2015-03-14T09:26:53.590Z";
+    private static final String DATE_TIME_1_STRING = "2015-03-14T09:26:53.59Z";
 
     private static final ZonedDateTime DATE_TIME_2 = ZonedDateTime.of(
             2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneId.of("Europe/Budapest"));
@@ -31,7 +31,7 @@ public class TestZonedDateTimeKeySerialization {
      * keeps offset data.
      */
     private static final ZonedDateTime DATE_TIME_2_OFFSET = DATE_TIME_2.withZoneSameInstant(ZoneOffset.ofHours(1));
-    private static final String DATE_TIME_2_STRING = "2015-03-14T09:26:53.590+01:00";;
+    private static final String DATE_TIME_2_STRING = "2015-03-14T09:26:53.59+01:00";;
 
     private ObjectMapper om;
     private Map<ZonedDateTime, String> map;
@@ -51,7 +51,7 @@ public class TestZonedDateTimeKeySerialization {
     public void testSerialization0() throws Exception {
         map.put(DATE_TIME_0, "test");
 
-        String value = om.writeValueAsString(map);
+        String value = om.writerFor(TYPE_REF).writeValueAsString(map);
 
         Assert.assertEquals("Value is incorrect", map(DATE_TIME_0_STRING, "test"), value);
     }
@@ -60,7 +60,7 @@ public class TestZonedDateTimeKeySerialization {
     public void testSerialization1() throws Exception {
         map.put(DATE_TIME_1, "test");
 
-        String value = om.writeValueAsString(map);
+        String value = om.writerFor(TYPE_REF).writeValueAsString(map);
 
         Assert.assertEquals("Value is incorrect", map(DATE_TIME_1_STRING, "test"), value);
     }
@@ -69,7 +69,7 @@ public class TestZonedDateTimeKeySerialization {
     public void testSerialization2() throws Exception {
         map.put(DATE_TIME_2, "test");
 
-        String value = om.writeValueAsString(map);
+        String value = om.writerFor(TYPE_REF).writeValueAsString(map);
 
         Assert.assertEquals("Value is incorrect", map(DATE_TIME_2_STRING, "test"), value);
     }

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeKeySerialization.java
@@ -1,15 +1,37 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestZonedDateTimeKeySerialization {
+
+    private static final TypeReference<Map<ZonedDateTime, String>> TYPE_REF = new TypeReference<Map<ZonedDateTime, String>>() {
+    };
+    private static final ZonedDateTime DATE_TIME_0 = ZonedDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC);
+    private static final String DATE_TIME_0_STRING = "1970-01-01T00:00Z";
+
+    private static final ZonedDateTime DATE_TIME_1 = ZonedDateTime.of(
+            2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneOffset.UTC);
+    private static final String DATE_TIME_1_STRING = "2015-03-14T09:26:53.590Z";
+
+    private static final ZonedDateTime DATE_TIME_2 = ZonedDateTime.of(
+            2015, 3, 14, 9, 26, 53, 590 * 1000 * 1000, ZoneId.of("Europe/Budapest"));
+    /**
+     * Value of {@link #DATE_TIME_2} after it's been serialized and read back. Serialization throws away time zone information, it only
+     * keeps offset data.
+     */
+    private static final ZonedDateTime DATE_TIME_2_OFFSET = DATE_TIME_2.withZoneSameInstant(ZoneOffset.ofHours(1));
+    private static final String DATE_TIME_2_STRING = "2015-03-14T09:26:53.590+01:00";;
 
     private ObjectMapper om;
     private Map<ZonedDateTime, String> map;
@@ -26,15 +48,54 @@ public class TestZonedDateTimeKeySerialization {
      */
 
     @Test
-    public void testSerialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization0() throws Exception {
+        map.put(DATE_TIME_0, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(DATE_TIME_0_STRING, "test"), value);
     }
 
     @Test
-    public void testDeserialization() {
-        // TODO test
-        Assert.fail("Not done yet");
+    public void testSerialization1() throws Exception {
+        map.put(DATE_TIME_1, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(DATE_TIME_1_STRING, "test"), value);
+    }
+
+    @Test
+    public void testSerialization2() throws Exception {
+        map.put(DATE_TIME_2, "test");
+
+        String value = om.writeValueAsString(map);
+
+        Assert.assertEquals("Value is incorrect", map(DATE_TIME_2_STRING, "test"), value);
+    }
+
+    @Test
+    public void testDeserialization0() throws Exception {
+        Map<ZonedDateTime, String> value = om.readValue(map(DATE_TIME_0_STRING, "test"), TYPE_REF);
+
+        map.put(DATE_TIME_0, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization1() throws Exception {
+        Map<ZonedDateTime, String> value = om.readValue(map(DATE_TIME_1_STRING, "test"), TYPE_REF);
+
+        map.put(DATE_TIME_1, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
+    }
+
+    @Test
+    public void testDeserialization2() throws Exception {
+        Map<ZonedDateTime, String> value = om.readValue(map(DATE_TIME_2_STRING, "test"), TYPE_REF);
+
+        map.put(DATE_TIME_2_OFFSET, "test");
+        Assert.assertEquals("Value is incorrect", map, value);
     }
 
     private String map(String key, String value) {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeKeySerialization.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestZonedDateTimeKeySerialization {
+
+    private ObjectMapper om;
+    private Map<ZonedDateTime, String> map;
+
+    @Before
+    public void setUp() {
+        this.om = new ObjectMapper();
+        om.registerModule(new JSR310Module());
+        map = new HashMap<>();
+    }
+
+    /*
+     * ObjectMapper configuration is not respected at deserialization and serialization at the moment.
+     */
+
+    @Test
+    public void testSerialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    @Test
+    public void testDeserialization() {
+        // TODO test
+        Assert.fail("Not done yet");
+    }
+
+    private String map(String key, String value) {
+        return String.format("{\"%s\":\"%s\"}", key, value);
+    }
+
+}


### PR DESCRIPTION
This is to resolve #18. Java 8 temporal types are supported as keys in `Map`s when deserializing. `ZonedDateTime` zone id data is not serialized, only the offset is (see #13 and related discussions).