### PR TITLE
Also accept ISO strings with time-component when deserializing LocalDate

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -77,11 +77,11 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                     return null;
                 }
 
-                try {
-                    return LocalDate.parse(string, _formatter);
-                } catch (DateTimeParseException e) {
+                if(string.contains("T")) {
                     return LocalDate.parse(string, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                 }
+                
+                return LocalDate.parse(string, _formatter);
         }
 
         throw context.wrongTokenException(parser, JsonToken.START_ARRAY, "Expected array or string.");

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Deserializer for Java 8 temporal {@link LocalDate}s.
@@ -76,13 +77,11 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                     return null;
                 }
 
-                // ignore timestamp if it is in the string
-                int timemarkerIndex = string.indexOf('T');
-                if(timemarkerIndex > -1) {
-                    string = string.substring(0, timemarkerIndex);
+                try {
+                    return LocalDate.parse(string, _formatter);
+                } catch (DateTimeParseException e) {
+                    return LocalDate.parse(string, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                 }
-
-                return LocalDate.parse(string, _formatter);
         }
 
         throw context.wrongTokenException(parser, JsonToken.START_ARRAY, "Expected array or string.");

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -75,6 +75,13 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                 if(string.length() == 0) {
                     return null;
                 }
+
+                // ignore timestamp if it is in the string
+                int timemarkerIndex = string.indexOf('T');
+                if(timemarkerIndex > -1) {
+                    string = string.substring(0, timemarkerIndex);
+                }
+
                 return LocalDate.parse(string, _formatter);
         }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerialization.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.format.DateTimeParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -156,6 +157,12 @@ public class TestLocalDateSerialization
 
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", date.toLocalDate(), value);
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testDeserializationAsString04() throws Exception
+    {
+        this.mapper.readValue("\"2015-06-19TShouldNotParse\"", LocalDate.class);
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerialization.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.temporal.Temporal;
 
@@ -144,6 +145,17 @@ public class TestLocalDateSerialization
 
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", date, value);
+    }
+
+    @Test
+    public void testDeserializationAsString03() throws Exception
+    {
+        LocalDateTime date = LocalDateTime.now();
+
+        LocalDate value = this.mapper.readValue('"' + date.toString() + '"', LocalDate.class);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.", date.toLocalDate(), value);
     }
 
     @Test


### PR DESCRIPTION
In JavaScript, we only have a single Date type, whose ```toJSON``` serializes it as ISO8601 string (e.g. ```2015-01-01T12:33:44```. It always includes the time component, even when using it only for the date-component:

```
var mydate = new Date("2015-01-01");
mydate.toJSON(); // results in "2015-01-01T00:00:00.000Z"
```

If you deserialize this into a Java ```LocalDate```, the current implementation blows up since it specifies the ISO format without time-component for parsing. This PR ignores the time-component from the serialized string when deserializing into a ```LocalDate```, making it more broadly useable.