### PR TITLE
Allow custom DateTimeFormatters

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -43,7 +43,7 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
         this(DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
-    protected LocalDateDeserializer(DateTimeFormatter dtf) {
+    public LocalDateDeserializer(DateTimeFormatter dtf) {
         super(LocalDate.class, dtf);
     }
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
@@ -42,13 +42,13 @@ public class LocalDateTimeDeserializer extends JSR310DateTimeDeserializerBase<Lo
         this(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 
-    protected LocalDateTimeDeserializer(DateTimeFormatter dtf) {
-        super(LocalDateTime.class, dtf);
+    public LocalDateTimeDeserializer(DateTimeFormatter formatter) {
+        super(LocalDateTime.class, formatter);
     }
     
     @Override
-    protected JsonDeserializer<LocalDateTime> withDateFormat(DateTimeFormatter dtf) {
-        return new LocalDateTimeDeserializer(dtf);
+    protected JsonDeserializer<LocalDateTime> withDateFormat(DateTimeFormatter formatter) {
+        return new LocalDateTimeDeserializer(formatter);
     }
     
     @Override

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
@@ -42,13 +42,13 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
         this(DateTimeFormatter.ISO_LOCAL_TIME);
     }
 
-    protected LocalTimeDeserializer(DateTimeFormatter dtf) {
-        super(LocalTime.class, dtf);
+    public LocalTimeDeserializer(DateTimeFormatter formatter) {
+        super(LocalTime.class, formatter);
     }
 
     @Override
-    protected JsonDeserializer<LocalTime> withDateFormat(DateTimeFormatter dtf) {
-        return new LocalTimeDeserializer(dtf);
+    protected JsonDeserializer<LocalTime> withDateFormat(DateTimeFormatter formatter) {
+        return new LocalTimeDeserializer(formatter);
     }
     
     @Override

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 
 import java.io.IOException;
 import java.time.Year;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Deserializer for Java 8 temporal {@link Year}s.
@@ -31,7 +32,7 @@ import java.time.Year;
 public class YearDeserializer extends JSR310DeserializerBase<Year>
 {
     private static final long serialVersionUID = 1L;
-
+    private DateTimeFormatter formatter;
     public static final YearDeserializer INSTANCE = new YearDeserializer();
 
     private YearDeserializer()
@@ -39,9 +40,17 @@ public class YearDeserializer extends JSR310DeserializerBase<Year>
         super(Year.class);
     }
 
+    public YearDeserializer(DateTimeFormatter formatter) {
+        super(Year.class);
+        this.formatter = formatter;
+    }
+
     @Override
     public Year deserialize(JsonParser parser, DeserializationContext context) throws IOException
     {
-        return Year.of(parser.getValueAsInt());
+        if (formatter == null) {
+            return Year.of(parser.getValueAsInt());
+        }
+        return Year.parse(parser.getValueAsString(), formatter);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
@@ -45,9 +45,9 @@ public class YearMonthDeserializer extends JSR310DateTimeDeserializerBase<YearMo
         this(DateTimeFormatter.ofPattern("uuuu-MM"));
     }
     
-    protected YearMonthDeserializer(DateTimeFormatter dtf) 
+    public YearMonthDeserializer(DateTimeFormatter formatter)
     {
-        super(YearMonth.class, dtf);
+        super(YearMonth.class, formatter);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateSerializer.java
@@ -44,6 +44,10 @@ public class LocalDateSerializer extends JSR310FormattedSerializerBase<LocalDate
         super(base, useTimestamp, dtf);
     }
 
+    public LocalDateSerializer(DateTimeFormatter formatter) {
+        super(LocalDate.class, formatter);
+    }
+
     @Override
     protected LocalDateSerializer withFormat(Boolean useTimestamp, DateTimeFormatter dtf) {
         return new LocalDateSerializer(this, useTimestamp, dtf);

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
@@ -38,17 +38,20 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
     public static final LocalDateTimeSerializer INSTANCE = new LocalDateTimeSerializer();
 
     protected LocalDateTimeSerializer() {
-        super(LocalDateTime.class);
+        this(null);
     }
 
-    private LocalDateTimeSerializer(LocalDateTimeSerializer base,
-            Boolean useTimestamp, DateTimeFormatter dtf) {
-        super(base, useTimestamp, dtf);
+    public LocalDateTimeSerializer(DateTimeFormatter formatter) {
+        super(LocalDateTime.class, formatter);
+    }
+
+    private LocalDateTimeSerializer(LocalDateTimeSerializer base, Boolean useTimestamp, DateTimeFormatter formatter) {
+        super(base, useTimestamp, formatter);
     }
 
     @Override
-    protected JSR310FormattedSerializerBase<LocalDateTime> withFormat(Boolean useTimestamp, DateTimeFormatter dtf) {
-        return new LocalDateTimeSerializer(this, useTimestamp, dtf);
+    protected JSR310FormattedSerializerBase<LocalDateTime> withFormat(Boolean useTimestamp, DateTimeFormatter formatter) {
+        return new LocalDateTimeSerializer(this, useTimestamp, formatter);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalTimeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalTimeSerializer.java
@@ -38,12 +38,15 @@ public class LocalTimeSerializer extends JSR310FormattedSerializerBase<LocalTime
     public static final LocalTimeSerializer INSTANCE = new LocalTimeSerializer();
 
     protected LocalTimeSerializer() {
-        super(LocalTime.class);
+        this(null);
     }
 
-    protected LocalTimeSerializer(LocalTimeSerializer base,
-            Boolean useTimestamp, DateTimeFormatter dtf) {
-        super(base, useTimestamp, dtf);
+    public LocalTimeSerializer(DateTimeFormatter formatter) {
+        super(LocalTime.class, formatter);
+    }
+
+    protected LocalTimeSerializer(LocalTimeSerializer base, Boolean useTimestamp, DateTimeFormatter formatter) {
+        super(base, useTimestamp, formatter);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/YearMonthSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/YearMonthSerializer.java
@@ -41,17 +41,20 @@ public class YearMonthSerializer extends JSR310FormattedSerializerBase<YearMonth
     public static final YearMonthSerializer INSTANCE = new YearMonthSerializer();
 
     private YearMonthSerializer() {
-        super(YearMonth.class);
+        this(null);
     }
 
-    private YearMonthSerializer(YearMonthSerializer base,
-            Boolean useTimestamp, DateTimeFormatter dtf) {
-        super(base, useTimestamp, dtf);
+    public YearMonthSerializer(DateTimeFormatter formatter) {
+        super(YearMonth.class, formatter);
+    }
+
+    private YearMonthSerializer(YearMonthSerializer base, Boolean useTimestamp, DateTimeFormatter formatter) {
+        super(base, useTimestamp, formatter);
     }
 
     @Override
-    protected YearMonthSerializer withFormat(Boolean useTimestamp, DateTimeFormatter dtf) {
-        return new YearMonthSerializer(this, useTimestamp, dtf);
+    protected YearMonthSerializer withFormat(Boolean useTimestamp, DateTimeFormatter formatter) {
+        return new YearMonthSerializer(this, useTimestamp, formatter);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/YearSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/YearSerializer.java
@@ -41,17 +41,20 @@ public class YearSerializer extends JSR310FormattedSerializerBase<Year>
     public static final YearSerializer INSTANCE = new YearSerializer();
 
     protected YearSerializer() {
-        super(Year.class);
+        this(null);
     }
 
-    protected YearSerializer(YearSerializer base,
-            Boolean useTimestamp, DateTimeFormatter dtf) {
-        super(base, useTimestamp, dtf);
+    public YearSerializer(DateTimeFormatter formatter) {
+        super(Year.class, formatter);
+    }
+
+    protected YearSerializer(YearSerializer base, Boolean useTimestamp, DateTimeFormatter formatter) {
+        super(base, useTimestamp, formatter);
     }
 
     @Override
-    protected YearSerializer withFormat(Boolean useTimestamp, DateTimeFormatter dtf) {
-        return new YearSerializer(this, useTimestamp, dtf);
+    protected YearSerializer withFormat(Boolean useTimestamp, DateTimeFormatter formatter) {
+        return new YearSerializer(this, useTimestamp, formatter);
     }
 
     @Override

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerializationWithCustomFormatter.java
@@ -1,0 +1,62 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.StringContains.containsString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TestLocalDateSerializationWithCustomFormatter {
+    private final DateTimeFormatter formatter;
+
+    public TestLocalDateSerializationWithCustomFormatter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        LocalDate date = LocalDate.now();
+        assertThat("Failed to serialize with " + formatter, serializeWith(date, formatter), containsString(date.format(formatter)));
+    }
+
+    private String serializeWith(LocalDate date, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addSerializer(new LocalDateSerializer(formatter)));
+        return mapper.writeValueAsString(date);
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        LocalDate date = LocalDate.now();
+        assertThat(deserializeWith(date.format(formatter), formatter), equalTo(date));
+    }
+
+    private LocalDate deserializeWith(String json, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addDeserializer(LocalDate.class, new LocalDateDeserializer(formatter)));
+        return mapper.readValue("\"" + json + "\"", LocalDate.class);
+    }
+
+    @Parameters
+    public static Collection<Object[]> customFormatters() {
+        Collection<Object[]> formatters = new ArrayList<>();
+        formatters.add(new Object[]{DateTimeFormatter.BASIC_ISO_DATE});
+        formatters.add(new Object[]{DateTimeFormatter.ISO_DATE});
+        formatters.add(new Object[]{DateTimeFormatter.ISO_LOCAL_DATE});
+        formatters.add(new Object[]{DateTimeFormatter.ISO_ORDINAL_DATE});
+        formatters.add(new Object[]{DateTimeFormatter.ISO_WEEK_DATE});
+        formatters.add(new Object[]{DateTimeFormatter.ofPattern("MM/dd/yyyy")});
+        return formatters;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerializationWithCustomFormatter.java
@@ -29,7 +29,7 @@ public class TestLocalDateSerializationWithCustomFormatter {
     @Test
     public void testSerialization() throws Exception {
         LocalDate date = LocalDate.now();
-        assertThat("Failed to serialize with " + formatter, serializeWith(date, formatter), containsString(date.format(formatter)));
+        assertThat(serializeWith(date, formatter), containsString(date.format(formatter)));
     }
 
     private String serializeWith(LocalDate date, DateTimeFormatter formatter) throws Exception {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeSerializationWithCustomFormatter.java
@@ -1,0 +1,62 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.StringContains.containsString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TestLocalDateTimeSerializationWithCustomFormatter {
+    private final DateTimeFormatter formatter;
+
+    public TestLocalDateTimeSerializationWithCustomFormatter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        LocalDateTime dateTime = LocalDateTime.now();
+        assertThat("Failed to serialize with " + formatter, serializeWith(dateTime, formatter), containsString(dateTime.format(formatter)));
+    }
+
+    private String serializeWith(LocalDateTime dateTime, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addSerializer(new LocalDateTimeSerializer(formatter)));
+        return mapper.writeValueAsString(dateTime);
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        LocalDateTime dateTime = LocalDateTime.now();
+        assertThat(deserializeWith(dateTime.format(formatter), formatter), equalTo(dateTime));
+    }
+
+    private LocalDateTime deserializeWith(String json, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(formatter)));
+        return mapper.readValue("\"" + json + "\"", LocalDateTime.class);
+    }
+
+    @Parameters
+    public static Collection<Object[]> customFormatters() {
+        Collection<Object[]> formatters = new ArrayList<>();
+        formatters.add(new Object[]{DateTimeFormatter.ISO_DATE_TIME});
+        formatters.add(new Object[]{DateTimeFormatter.ISO_LOCAL_DATE_TIME});
+        return formatters;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeSerializationWithCustomFormatter.java
@@ -33,7 +33,7 @@ public class TestLocalDateTimeSerializationWithCustomFormatter {
     @Test
     public void testSerialization() throws Exception {
         LocalDateTime dateTime = LocalDateTime.now();
-        assertThat("Failed to serialize with " + formatter, serializeWith(dateTime, formatter), containsString(dateTime.format(formatter)));
+        assertThat(serializeWith(dateTime, formatter), containsString(dateTime.format(formatter)));
     }
 
     private String serializeWith(LocalDateTime dateTime, DateTimeFormatter formatter) throws Exception {

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeSerializationWithCustomFormatter.java
@@ -1,0 +1,59 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.StringContains.containsString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TestLocalTimeSerializationWithCustomFormatter {
+    private final DateTimeFormatter formatter;
+
+    public TestLocalTimeSerializationWithCustomFormatter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        LocalTime dateTime = LocalTime.now();
+        assertThat(serializeWith(dateTime, formatter), containsString(dateTime.format(formatter)));
+    }
+
+    private String serializeWith(LocalTime dateTime, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addSerializer(new LocalTimeSerializer(formatter)));
+        return mapper.writeValueAsString(dateTime);
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        LocalTime dateTime = LocalTime.now();
+        assertThat(deserializeWith(dateTime.format(formatter), formatter), equalTo(dateTime));
+    }
+
+    private LocalTime deserializeWith(String json, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addDeserializer(LocalTime.class, new LocalTimeDeserializer(formatter)));
+        return mapper.readValue("\"" + json + "\"", LocalTime.class);
+    }
+
+    @Parameters
+    public static Collection<Object[]> customFormatters() {
+        Collection<Object[]> formatters = new ArrayList<>();
+        formatters.add(new Object[]{DateTimeFormatter.ISO_LOCAL_TIME});
+        formatters.add(new Object[]{DateTimeFormatter.ISO_TIME});
+        return formatters;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthSerializationWithCustomFormatter.java
@@ -52,6 +52,7 @@ public class TestYearMonthSerializationWithCustomFormatter {
     public static Collection<Object[]> customFormatters() {
         Collection<Object[]> formatters = new ArrayList<>();
         formatters.add(new Object[]{DateTimeFormatter.ofPattern("uuuu-MM")});
+        formatters.add(new Object[]{DateTimeFormatter.ofPattern("uu-M")});
         return formatters;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthSerializationWithCustomFormatter.java
@@ -1,0 +1,57 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.StringContains.containsString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.YearMonthSerializer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TestYearMonthSerializationWithCustomFormatter {
+    private final DateTimeFormatter formatter;
+
+    public TestYearMonthSerializationWithCustomFormatter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        YearMonth dateTime = YearMonth.now();
+        assertThat(serializeWith(dateTime, formatter), containsString(dateTime.format(formatter)));
+    }
+
+    private String serializeWith(YearMonth dateTime, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addSerializer(new YearMonthSerializer(formatter)));
+        return mapper.writeValueAsString(dateTime);
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        YearMonth dateTime = YearMonth.now();
+        assertThat(deserializeWith(dateTime.format(formatter), formatter), equalTo(dateTime));
+    }
+
+    private YearMonth deserializeWith(String json, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addDeserializer(YearMonth.class, new YearMonthDeserializer(formatter)));
+        return mapper.readValue("\"" + json + "\"", YearMonth.class);
+    }
+
+    @Parameters
+    public static Collection<Object[]> customFormatters() {
+        Collection<Object[]> formatters = new ArrayList<>();
+        formatters.add(new Object[]{DateTimeFormatter.ofPattern("uuuu-MM")});
+        return formatters;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearSerializationWithCustomFormatter.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearSerializationWithCustomFormatter.java
@@ -1,0 +1,59 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.StringContains.containsString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.YearDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.YearSerializer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.time.Year;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TestYearSerializationWithCustomFormatter {
+    private final DateTimeFormatter formatter;
+
+    public TestYearSerializationWithCustomFormatter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        Year year = Year.now();
+        String expected = "\"" + year.format(formatter) + "\"";
+        assertThat(serializeWith(year, formatter), equalTo(expected));
+    }
+
+    private String serializeWith(Year dateTime, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addSerializer(new YearSerializer(formatter)));
+        return mapper.writeValueAsString(dateTime);
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        Year dateTime = Year.now();
+        assertThat(deserializeWith(dateTime.format(formatter), formatter), equalTo(dateTime));
+    }
+
+    private Year deserializeWith(String json, DateTimeFormatter formatter) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addDeserializer(Year.class, new YearDeserializer(formatter)));
+        return mapper.readValue("\"" + json + "\"", Year.class);
+    }
+
+    @Parameters
+    public static Collection<Object[]> customFormatters() {
+        Collection<Object[]> formatters = new ArrayList<>();
+        formatters.add(new Object[]{DateTimeFormatter.ofPattern("yyyy")});
+        formatters.add(new Object[]{DateTimeFormatter.ofPattern("yy")});
+        return formatters;
+    }
+}


### PR DESCRIPTION
Allow users of the api pass in a custom formatter to the LocalDateSerializer/Deserializer.

This is a possible approach to solving issue #17 

We only implemented what was necessary in LocalDateSerializer and LocalDateDeserialize, which were the two classes we needed to solve our problem.  If this approach looks good we are willing to extend this to the other relevant Serializers and Deserializers.
