### PR TITLE
Handle JSON serialized Dates from JavaScript in LocalDateDeserializer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -17,7 +17,10 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.core.*;
@@ -64,9 +67,14 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
             // if we are using default formatter
             DateTimeFormatter format = _formatter;
             if (format == DEFAULT_FORMATTER) {
-	            if (string.contains("T")) {
-	                return LocalDate.parse(string, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-	            }
+                // JavaScript by default includes time in JSON serialized Dates (UTC/ISO instant format).
+                if (string.length() > 10 && string.charAt(10) == 'T') {
+                   if (string.endsWith("Z")) {
+                       return LocalDateTime.ofInstant(Instant.parse(string), ZoneOffset.UTC).toLocalDate();
+                   } else {
+                       return LocalDate.parse(string, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+                   }
+                }
             }
             return LocalDate.parse(string, format);
     	}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateSerialization.java
@@ -21,9 +21,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.format.DateTimeParseException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -169,6 +171,16 @@ public class TestLocalDateSerialization
     public void testDeserializationAsString04() throws Exception
     {
         this.MAPPER.readValue("\"2015-06-19TShouldNotParse\"", LocalDate.class);
+    }
+
+    @Test
+    public void testDeserializationAsString05() throws Exception
+    {
+        Instant instant = Instant.now();
+        LocalDate value = MAPPER.readValue('"' + instant.toString() + '"', LocalDate.class);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.", LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toLocalDate(), value);
     }
 
     @Test


### PR DESCRIPTION
I've been at this before (https://github.com/FasterXML/jackson-datatype-jsr310/pull/27), however, during the review phase of the PR I accidentally borked my own use-case. Unfortunately I only found out after we switched from our internally patched version to the current 2.7 release. 

It's now possible to parse a date and time ("2016-01-18T15:41:32.232") as LocalDate. However, what I needed was to be able to parse this, coming from JavaScript:

```
new Date().toJSON()
"2016-01-18T14:09:30.163Z"
```
(notice the trailing Z, which is currently not accepted)

JavaScript generates an ISO instant string when serialising a JavaScript Date [1]. It seems I am not the only one running into this issue [2]. I think it would be great to revise my original PR to allow for this.  That way, it works for many people doing Java/JS interop without having to override the pattern on each usage of a LocalDate field. The check for custom formatter (https://github.com/FasterXML/jackson-datatype-jsr310/issues/37) is obviously still in place. I also made the check for the presence of the time component a bit more robust.

Thanks for considering this PR. My CLA is already in place, so that should not be an issue.

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON & https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
[2] http://stackoverflow.com/questions/26233882/javascript-date-to-java-time-localdate & http://stackoverflow.com/questions/5591967/how-to-deserialize-js-date-using-jackson