### PR TITLE
Casting math operands

### DIFF
--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationKeySerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationKeySerialization.java
@@ -15,7 +15,7 @@ public class TestDurationKeySerialization {
 
     private static final TypeReference<Map<Duration, String>> TYPE_REF = new TypeReference<Map<Duration, String>>() {
     };
-    private static final Duration DURATION = Duration.ofMinutes(13).plusSeconds(37).plusNanos(120 * 1000 * 1000);
+    private static final Duration DURATION = Duration.ofMinutes(13).plusSeconds(37).plusNanos(120 * 1000 * 1000L);
     private static final String DURATION_STRING = "PT13M37.12S";
 
     private ObjectMapper om;

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeSerialization.java
@@ -427,7 +427,7 @@ public class TestOffsetDateTimeSerialization
     public void testDeserializationAsInt03MillisecondsWithoutTimeZone() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.now(Z3);
-        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000), ChronoUnit.NANOS);
+        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000L), ChronoUnit.NANOS);
 
         this.mapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
         OffsetDateTime value =
@@ -442,7 +442,7 @@ public class TestOffsetDateTimeSerialization
     public void testDeserializationAsInt03MillisecondsWithTimeZone() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.now(Z3);
-        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000), ChronoUnit.NANOS);
+        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000L), ChronoUnit.NANOS);
 
         this.mapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
         this.mapper.setTimeZone(TimeZone.getDefault());

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeSerialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeSerialization.java
@@ -453,7 +453,7 @@ public class TestZonedDateTimeSerialization
     public void testDeserializationAsInt03MillisecondsWithoutTimeZone() throws Exception
     {
         ZonedDateTime date = ZonedDateTime.now(Z3);
-        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000), ChronoUnit.NANOS);
+        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000L), ChronoUnit.NANOS);
 
         this.mapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
         ZonedDateTime value =
@@ -468,7 +468,7 @@ public class TestZonedDateTimeSerialization
     public void testDeserializationAsInt03MillisecondsWithTimeZone() throws Exception
     {
         ZonedDateTime date = ZonedDateTime.now(Z3);
-        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000), ChronoUnit.NANOS);
+        date = date.minus(date.getNano() - (date.get(ChronoField.MILLI_OF_SECOND) * 1_000_000L), ChronoUnit.NANOS);
 
         this.mapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
         this.mapper.setTimeZone(TimeZone.getDefault());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - “ Math operands should be cast before assignment”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
Ayman Abdelghany.