### PR TITLE
tests for deserializing java.time.X's by String

### DIFF
--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeDeserialization.java
@@ -1,0 +1,65 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestLocalDateTimeDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(LocalDateTime.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(LocalDateTime.of(2000, Month.JANUARY, 1, 12, 0), "'2000-01-01T12:00'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notalocaldatetime'");
+    }
+
+    private void expectFailure(String json) throws Throwable {
+        try {
+            read(json);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String json) throws IOException {
+        final LocalDateTime value = read(json);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private LocalDateTime read(final String json) throws IOException {
+        return READER.readValue(aposToQuotes(json));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeDeserialization.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestLocalTimeDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(LocalTime.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(LocalTime.of(12, 0), "'12:00'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notalocaltime'");
+    }
+
+    private void expectFailure(String aposJson) throws Throwable {
+        try {
+            read(aposJson);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String aposJson) throws IOException {
+        final LocalTime value = read(aposJson);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private LocalTime read(final String aposJson) throws java.io.IOException {
+        return READER.readValue(aposToQuotes(aposJson));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayDeserialization.java
@@ -1,0 +1,65 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestMonthDayDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(MonthDay.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(MonthDay.of(Month.JANUARY, 1), "'--01-01'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notamonthday'");
+    }
+
+    private void expectFailure(String aposJson) throws Throwable {
+        try {
+            read(aposJson);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String aposJson) throws IOException {
+        final MonthDay value = read(aposJson);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private MonthDay read(final String aposJson) throws IOException {
+        return READER.readValue(aposToQuotes(aposJson));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeDeserialization.java
@@ -1,0 +1,65 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestOffsetDateTimeDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(OffsetDateTime.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(OffsetDateTime.of(2000, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC), "'2000-01-01T12:00Z'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notanoffsetdatetime'");
+    }
+
+    private void expectFailure(String json) throws Throwable {
+        try {
+            read(json);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String json) throws IOException {
+        final OffsetDateTime value = read(json);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private OffsetDateTime read(final String json) throws IOException {
+        return READER.readValue(aposToQuotes(json));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeDeserialization.java
@@ -1,0 +1,65 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestOffsetTimeDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(OffsetTime.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC), "'12:00Z'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notanoffsettime'");
+    }
+
+    private void expectFailure(String json) throws Throwable {
+        try {
+            read(json);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String json) throws IOException {
+        final OffsetTime value = read(json);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private OffsetTime read(final String json) throws IOException {
+        return READER.readValue(aposToQuotes(json));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearDeserialization.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Year;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestYearDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(Year.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(Year.of(2000), "'2000'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notayear'");
+    }
+
+    private void expectFailure(String json) throws Throwable {
+        try {
+            read(json);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String json) throws IOException {
+        final Year value = read(json);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private Year read(final String json) throws IOException {
+        return READER.readValue(aposToQuotes(json));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthDeserialization.java
@@ -1,0 +1,65 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestYearMonthDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(YearMonth.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(YearMonth.of(2000, Month.JANUARY), "'2000-01'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notayearmonth'");
+    }
+
+    private void expectFailure(String json) throws Throwable {
+        try {
+            read(json);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String json) throws IOException {
+        final YearMonth value = read(json);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private YearMonth read(final String json) throws IOException {
+        return READER.readValue(aposToQuotes(json));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeDeserialization.java
@@ -1,0 +1,65 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestZonedDateTimeDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(ZonedDateTime.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(ZonedDateTime.of(2000, 1, 1, 12, 0, 0, 0, ZoneId.of("UTC")), "'2000-01-01T12:00Z'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notazone'");
+    }
+
+    private void expectFailure(String json) throws Throwable {
+        try {
+            read(json);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String json) throws IOException {
+        final ZonedDateTime value = read(json);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private ZonedDateTime read(final String json) throws IOException {
+        return READER.readValue(aposToQuotes(json));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedOffsetDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedOffsetDeserialization.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.datatype.jsr310;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestZonedOffsetDeserialization extends ModuleTestBase
+{
+    private final ObjectReader READER = newMapper().readerFor(ZoneOffset.class);
+
+    @Test
+    public void testDeserializationAsString01() throws Exception
+    {
+        expectSuccess(ZoneOffset.of("+0300"), "'+0300'");
+    }
+
+    @Test
+    public void testBadDeserializationAsString01() throws Throwable
+    {
+        expectFailure("'notazonedoffset'");
+    }
+
+    private void expectFailure(String json) throws Throwable {
+        try {
+            read(json);
+            fail("expected DateTimeParseException");
+        } catch (JsonProcessingException e) {
+            if (e.getCause() == null) {
+                throw e;
+            }
+            if (!(e.getCause() instanceof DateTimeParseException)) {
+                throw e.getCause();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    private void expectSuccess(Object exp, String json) throws IOException {
+        final ZoneOffset value = read(json);
+        notNull(value);
+        expect(exp, value);
+    }
+
+    private ZoneOffset read(final String json) throws IOException {
+        return READER.readValue(aposToQuotes(json));
+    }
+
+    private static void notNull(Object value) {
+        assertNotNull("The value should not be null.", value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp,  value);
+    }
+}


### PR DESCRIPTION
In relationship to https://github.com/FasterXML/jackson-datatype-jsr310/issues/63