### PR TITLE
Use InvalidFormatException for deserialization parse failures

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.time.DateTimeException;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 
 /**
  * Deserializer for Java 8 temporal {@link Duration}s.
@@ -68,8 +68,8 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
                 }
                 try {
                     return Duration.parse(string);
-                } catch (DateTimeException e) {
-                    _rethrowDateTimeException(parser, e);
+                } catch (DateTimeParseException e) {
+                    throw context.weirdStringException(string, handledType(), e.getMessage());
                 }
         }
         throw context.mappingException("Expected type float, integer, or string.");

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -31,6 +31,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.util.function.BiFunction;
@@ -152,6 +153,8 @@ public class InstantDeserializer<T extends Temporal>
                     if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
                         return adjust.apply(value, this.getZone(context));
                     }
+                } catch (DateTimeParseException e) {
+                    throw context.weirdStringException(string, handledType(), e.getMessage());
                 } catch (DateTimeException e) {
                     _rethrowDateTimeException(parser, e);
                     value = null;

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
@@ -88,7 +88,7 @@ public class JSR310StringParsableDeserializer
                     return ZoneOffset.of(string);
                 }
             } catch (DateTimeException e) {
-                _rethrowDateTimeException(parser, e);
+                throw context.weirdStringException(string, handledType(), e.getMessage());
             }
         }
         throw context.wrongTokenException(parser, JsonToken.VALUE_STRING, null);

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -78,6 +79,8 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                     }
                 }
                 return LocalDate.parse(string, format);
+            } catch (DateTimeParseException e) {
+                throw context.weirdStringException(string, handledType(), e.getMessage());
             } catch (DateTimeException e) {
                 _rethrowDateTimeException(parser, e);
             }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -81,6 +82,8 @@ public class LocalDateTimeDeserializer
 	            }
 
                 return LocalDateTime.parse(string, _formatter);
+            } catch (DateTimeParseException e) {
+                throw context.weirdStringException(string, handledType(), e.getMessage());
             } catch (DateTimeException e) {
                 _rethrowDateTimeException(parser, e);
             }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Deserializer for Java 8 temporal {@link LocalTime}s.
@@ -70,8 +70,8 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
     	            }
                 }
                 return LocalTime.parse(string, format);
-            } catch (DateTimeException e) {
-                _rethrowDateTimeException(parser, e);
+            } catch (DateTimeParseException e) {
+                throw context.weirdStringException(string, handledType(), e.getMessage());
             }
         }
         if (parser.isExpectedStartArrayToken()) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.MonthDay;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -38,8 +38,8 @@ public class MonthDayDeserializer extends JSR310DateTimeDeserializerBase<MonthDa
                     return MonthDay.parse(str);
                 }
                 return MonthDay.parse(str, _formatter);
-            } catch (DateTimeException e) {
-                _rethrowDateTimeException(parser, e);
+            } catch (DateTimeParseException e) {
+                throw context.weirdStringException(str, handledType(), e.getMessage());
             }
         }
         throw context.mappingException("Unexpected token (%s), expected VALUE_STRING or VALUE_NUMBER_INT",

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
@@ -17,10 +17,10 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
@@ -59,8 +59,8 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
             }
             try {
                 return OffsetTime.parse(string, _formatter);
-            } catch (DateTimeException e) {
-                _rethrowDateTimeException(parser, e);
+            } catch (DateTimeParseException e) {
+                throw context.weirdStringException(string, handledType(), e.getMessage());
             }
         }
         if (!parser.isExpectedStartArrayToken()) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Deserializer for Java 8 temporal {@link Year}s.
@@ -60,8 +60,8 @@ public class YearDeserializer extends JSR310DeserializerBase<Year>
                     return Year.parse(str);
                 }
                 return Year.parse(str, _formatter);
-            } catch (DateTimeException e) {
-                _rethrowDateTimeException(parser, e);
+            } catch (DateTimeParseException e) {
+                throw context.weirdStringException(str, handledType(), e.getMessage());
             }
         }
         if (t == JsonToken.VALUE_NUMBER_INT) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Deserializer for Java 8 temporal {@link YearMonth}s.
@@ -64,8 +64,8 @@ public class YearMonthDeserializer extends JSR310DateTimeDeserializerBase<YearMo
             }
             try {
                 return YearMonth.parse(string, _formatter);
-            } catch (DateTimeException e) {
-                _rethrowDateTimeException(parser, e);
+            } catch (DateTimeParseException e) {
+                throw context.weirdStringException(string, handledType(), e.getMessage());
             }
         }
         if (parser.isExpectedStartArrayToken()) {

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/DurationKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/DurationKeyDeserializer.java
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -18,8 +18,8 @@ public class DurationKeyDeserializer extends Jsr310KeyDeserializer {
     protected Duration deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return Duration.parse(key);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, Duration.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(Duration.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/InstantKeyDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -19,8 +19,8 @@ public class InstantKeyDeserializer extends Jsr310KeyDeserializer {
     protected Instant deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return DateTimeFormatter.ISO_INSTANT.parse(key, Instant::from);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, Instant.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(Instant.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateKeyDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -19,8 +19,8 @@ public class LocalDateKeyDeserializer extends Jsr310KeyDeserializer {
     protected LocalDate deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return LocalDate.parse(key, DateTimeFormatter.ISO_LOCAL_DATE);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, LocalDate.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(LocalDate.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalDateTimeKeyDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -19,8 +19,8 @@ public class LocalDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
     protected LocalDateTime deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return LocalDateTime.parse(key, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, LocalDateTime.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(LocalDateTime.class, key, e.getMessage());
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/LocalTimeKeyDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -19,8 +19,8 @@ public class LocalTimeKeyDeserializer extends Jsr310KeyDeserializer {
     protected LocalTime deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return LocalTime.parse(key, DateTimeFormatter.ISO_LOCAL_TIME);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, LocalTime.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(LocalTime.class, key, e.getMessage());
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/MonthDayKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/MonthDayKeyDeserializer.java
@@ -4,10 +4,10 @@ import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.MonthDay;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -31,8 +31,8 @@ public class MonthDayKeyDeserializer extends Jsr310KeyDeserializer {
     protected MonthDay deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return MonthDay.parse(key, PARSER);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, MonthDay.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(MonthDay.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetDateTimeKeyDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -19,8 +19,8 @@ public class OffsetDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
     protected OffsetDateTime deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return OffsetDateTime.parse(key, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, OffsetDateTime.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(OffsetDateTime.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/OffsetTimeKeyDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.OffsetTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -19,8 +19,8 @@ public class OffsetTimeKeyDeserializer extends Jsr310KeyDeserializer {
     protected OffsetTime deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return OffsetTime.parse(key, DateTimeFormatter.ISO_OFFSET_TIME);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, OffsetTime.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(OffsetTime.class, key, e.getMessage());
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/PeriodKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/PeriodKeyDeserializer.java
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.Period;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -18,8 +18,8 @@ public class PeriodKeyDeserializer extends Jsr310KeyDeserializer {
     protected Period deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return Period.parse(key);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, Period.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(Period.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
@@ -3,10 +3,10 @@ package com.fasterxml.jackson.datatype.jsr310.deser.key;
 import static java.time.temporal.ChronoField.YEAR;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.format.SignStyle;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -30,8 +30,8 @@ public class YearKeyDeserializer extends Jsr310KeyDeserializer {
     protected Year deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return Year.parse(key, FORMATTER);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, Year.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(Year.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearMothKeyDeserializer.java
@@ -4,10 +4,10 @@ import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.YEAR;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.format.SignStyle;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -31,8 +31,8 @@ public class YearMothKeyDeserializer extends Jsr310KeyDeserializer {
     protected YearMonth deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
             return YearMonth.parse(key, FORMATTER);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, YearMonth.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(YearMonth.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneIdKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneIdKeyDeserializer.java
@@ -19,7 +19,7 @@ public class ZoneIdKeyDeserializer extends Jsr310KeyDeserializer {
         try {
             return ZoneId.of(key);
         } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, ZoneId.class, e);
+            throw ctxt.weirdKeyException(ZoneId.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneOffsetKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZoneOffsetKeyDeserializer.java
@@ -19,7 +19,7 @@ public class ZoneOffsetKeyDeserializer extends Jsr310KeyDeserializer {
         try {
             return ZoneOffset.of(key);
         } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, ZoneOffset.class, e);
+            throw ctxt.weirdKeyException(ZoneOffset.class, key, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -20,8 +20,8 @@ public class ZonedDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
         // not serializing timezone data yet
         try {
             return ZonedDateTime.parse(key, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-        } catch (DateTimeException e) {
-            return _rethrowDateTimeException(ctxt, ZonedDateTime.class, e);
+        } catch (DateTimeParseException e) {
+            throw ctxt.weirdKeyException(ZonedDateTime.class, key, e.getMessage());
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalDateTimeDeserialization.java
@@ -1,13 +1,12 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,16 +31,9 @@ public class TestLocalDateTimeDeserialization extends ModuleTestBase
     private void expectFailure(String json) throws Throwable {
         try {
             read(json);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(LocalDateTime.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestLocalTimeDeserialization.java
@@ -1,12 +1,11 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.LocalTime;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -31,16 +30,9 @@ public class TestLocalTimeDeserialization extends ModuleTestBase
     private void expectFailure(String aposJson) throws Throwable {
         try {
             read(aposJson);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(LocalTime.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestMonthDayDeserialization.java
@@ -1,13 +1,12 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Month;
 import java.time.MonthDay;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,16 +31,9 @@ public class TestMonthDayDeserialization extends ModuleTestBase
     private void expectFailure(String aposJson) throws Throwable {
         try {
             read(aposJson);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(MonthDay.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetDateTimeDeserialization.java
@@ -1,14 +1,13 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -52,16 +51,9 @@ public class TestOffsetDateTimeDeserialization extends ModuleTestBase
     private void expectFailure(String json) throws Throwable {
         try {
             read(json);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(OffsetDateTime.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestOffsetTimeDeserialization.java
@@ -1,13 +1,12 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,16 +31,9 @@ public class TestOffsetTimeDeserialization extends ModuleTestBase
     private void expectFailure(String json) throws Throwable {
         try {
             read(json);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(OffsetTime.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearDeserialization.java
@@ -1,12 +1,11 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Year;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -31,16 +30,9 @@ public class TestYearDeserialization extends ModuleTestBase
     private void expectFailure(String json) throws Throwable {
         try {
             read(json);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(Year.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestYearMonthDeserialization.java
@@ -1,13 +1,12 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Month;
 import java.time.YearMonth;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,16 +31,9 @@ public class TestYearMonthDeserialization extends ModuleTestBase
     private void expectFailure(String json) throws Throwable {
         try {
             read(json);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(YearMonth.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedDateTimeDeserialization.java
@@ -1,13 +1,12 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,16 +31,9 @@ public class TestZonedDateTimeDeserialization extends ModuleTestBase
     private void expectFailure(String json) throws Throwable {
         try {
             read(json);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            if (e.getCause() == null) {
-                throw e;
-            }
-            if (!(e.getCause() instanceof DateTimeParseException)) {
-                throw e.getCause();
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(ZonedDateTime.class, e.getTargetType());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedOffsetDeserialization.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestZonedOffsetDeserialization.java
@@ -1,12 +1,11 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.ZoneOffset;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.junit.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import static org.junit.Assert.assertEquals;
@@ -32,17 +31,9 @@ public class TestZonedOffsetDeserialization extends ModuleTestBase
     private void expectFailure(String json) throws Throwable {
         try {
             read(json);
-            fail("expected DateTimeParseException");
-        } catch (JsonProcessingException e) {
-            Throwable rootCause = e.getCause();
-            if (rootCause == null) {
-                fail("Failed as expected, but no root cause for "+e);
-            }
-            if (!(rootCause instanceof DateTimeException)) {
-                fail("Failed as expected, but wrong root cause type: "+rootCause.getClass());
-            }
-        } catch (IOException e) {
-            throw e;
+            fail("expected InvalidFormatException");
+        } catch (InvalidFormatException e) {
+            assertEquals(ZoneOffset.class, e.getTargetType());
         }
     }
 


### PR DESCRIPTION
This alters the behaviour of the deserializers to throw more specific InvalidFormatExceptions rather than JsonMappingExceptions, initially discussed in dropwizard/dropwizard#1527.

Since this does change behaviour -- exceptions will no longer have a cause of type DateTimeException (or any nested cause at all) -- I'm not sure if it is acceptable for a patch release.

