### PR TITLE
output LocalDate json schema format as DATE

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateSerializer.java
@@ -67,4 +67,19 @@ public class LocalDateSerializer extends JSR310FormattedSerializerBase<LocalDate
             generator.writeString(str);
         }
     }
+    
+    @Override
+    public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint) throws JsonMappingException
+    {
+        SerializerProvider provider = visitor.getProvider();
+        boolean useTimestamp = (provider != null) && useTimestamp(provider);
+        if (useTimestamp) {
+            _acceptTimestampVisitor(visitor, typeHint);
+        } else {
+            JsonStringFormatVisitor v2 = visitor.expectStringFormat(typeHint);
+            if (v2 != null) {
+                v2.format(JsonValueFormat.DATE);
+            }
+        }
+    }
 }


### PR DESCRIPTION
What I want to happen is for LocalDate types' generated swagger spec to output 
`"format" : "date"` instead of `"format" : "date-time"`.

This works locally, and it seems like LocalDates should always be formatted as a `date` in the spec.  Need a test for this? If so, can you point me to an example existing test? 

Otherwise, thoughts?  Thanks.