### PR TITLE
Remove dead codehaus link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Datatype module to make Jackson (http://jackson.codehaus.org) recognize Java 8 Date & Time API data types (JSR-310).
+Datatype module to make Jackson recognize Java 8 Date & Time API data types (JSR-310).
 
 ## Status
 


### PR DESCRIPTION
I don't think there's a good replacement (FasterXML's site is _also_ down), so it's probably best to just remove this for now.